### PR TITLE
Use secure URI in Vcs-Git control header

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9),
                qtdeclarative5-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/xiaoyong/2048-Qt
-Vcs-Git: git://github.com/mogaal/2048-qt.git
+Vcs-Git: https://github.com/mogaal/2048-qt.git
 Vcs-Browser: https://github.com/mogaal/2048-qt
 
 Package: 2048-qt


### PR DESCRIPTION
Use securi URI for Vcs-Git file header.

Fixes lintian: vcs-field-uses-insecure-uri
https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html
